### PR TITLE
fix(forum): adjust reaction picker positioning for improved UX

### DIFF
--- a/src/components/features/forum/ReactionButton.component.tsx
+++ b/src/components/features/forum/ReactionButton.component.tsx
@@ -42,7 +42,7 @@ export function ReactionButton({
         picker.style.left = '0';
         picker.style.transform = 'translateX(0)';
       } else {
-        picker.style.left = '100%';
+        picker.style.left = '150%';
         picker.style.transform = 'translateX(-50%)';
       }
     }


### PR DESCRIPTION
- Updated the positioning of the reaction picker in ReactionButton to prevent overflow issues on mobile devices by changing its left style from 100% to 150%.
- This adjustment enhances the user experience by ensuring the picker is more accessible and visually aligned.