### PR TITLE
chore: remove standalone output option from Next.js config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "npm run build"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"
+
+[build.environment]
+  NODE_VERSION = "18" 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,0 @@
-[build]
-  command = "npm run build"
-
-[[plugins]]
-  package = "@netlify/plugin-nextjs"
-
-[build.environment]
-  NODE_VERSION = "18" 

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   /* config options here */
-  output: "standalone",
   images: {
     unoptimized: true,
     domains: ["lh3.googleusercontent.com", "www.google.com"],


### PR DESCRIPTION
- Removed the `output: "standalone"` option from `next.config.js` to streamline the configuration.
- This change aligns with the current project setup and optimizes the build process.